### PR TITLE
RefreshToken JWT -> UUID 변경, Token 발급 및 제거 기능 추가, 보안 및 에러 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Log
+	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/inthefridges/api/controller/member/RefreshTokenController.java
+++ b/src/main/java/com/inthefridges/api/controller/member/RefreshTokenController.java
@@ -1,7 +1,9 @@
 package com.inthefridges.api.controller.member;
 
 import com.inthefridges.api.global.security.jwt.JwtService;
+import com.inthefridges.api.global.security.jwt.model.Tokens;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,14 +17,37 @@ public class RefreshTokenController {
     public ResponseEntity<String> refreshAccessToken(
             @CookieValue("refreshToken") String refreshToken
     ) {
-        String accessToken = jwtService.getAccessTokensByRefreshToken(refreshToken);
-        return ResponseEntity.ok().body(accessToken);
+        Tokens tokens = jwtService.getAccessTokensByRefreshToken(refreshToken);
+        ResponseCookie responseCookie = setRefreshTokenInCookie(tokens.refreshToken());
+        return ResponseEntity.ok()
+                .header("Set-Cookie", responseCookie.toString())
+                .body(tokens.accessToken());
     }
 
     @DeleteMapping
     public ResponseEntity<Void> expireRefreshToken(@CookieValue("refreshToken") String refreshToken){
         jwtService.deleteRefreshToken(refreshToken);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent()
+                .header("Set-Cookie", removeCookie().toString()).build();
+    }
+
+    private ResponseCookie setRefreshTokenInCookie(String refreshToken){
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .path("/")
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .maxAge(jwtService.getRefreshExpirationMillis())
+                .build();
+    }
+
+    private ResponseCookie removeCookie() {
+        return ResponseCookie.from("refreshToken", null)
+                .maxAge(0)
+                .path("/")
+                .secure(true)
+                .httpOnly(true)
+                .build();
     }
 
 }

--- a/src/main/java/com/inthefridges/api/entity/RefreshToken.java
+++ b/src/main/java/com/inthefridges/api/entity/RefreshToken.java
@@ -15,6 +15,7 @@ public class RefreshToken {
     private Long memberId;
     private String token;
     private String role;
+    private Date expiryDate;
     private Date createAt;
     private Date deletedAt;
 }

--- a/src/main/java/com/inthefridges/api/entity/RefreshToken.java
+++ b/src/main/java/com/inthefridges/api/entity/RefreshToken.java
@@ -12,6 +12,7 @@ import java.util.Date;
 @AllArgsConstructor
 @Builder
 public class RefreshToken {
+    private Long id;
     private Long memberId;
     private String token;
     private String role;

--- a/src/main/java/com/inthefridges/api/entity/RefreshToken.java
+++ b/src/main/java/com/inthefridges/api/entity/RefreshToken.java
@@ -18,4 +18,5 @@ public class RefreshToken {
     private Date expiryDate;
     private Date createAt;
     private Date deletedAt;
+    private Date updatedAt;
 }

--- a/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
+++ b/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
@@ -24,9 +24,9 @@ public enum ExceptionCode {
     EXPIRED_TOKEN("A004", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_TOKEN("A005", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     USER_NOT_FOUND("A006", HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-    NOT_FOUND_COOKIE("A007",HttpStatus.UNAUTHORIZED, "쿠키를 찾을 수 없습니다."),
-    NOT_FOUND_REFRESH_TOKEN("A008",HttpStatus.NOT_FOUND, "유효하지 않은 리프레쉬 토큰입니다."),;
-
+    NOT_FOUND_COOKIE("A007", HttpStatus.UNAUTHORIZED, "쿠키를 찾을 수 없습니다."),
+    NOT_FOUND_REFRESH_TOKEN("A008", HttpStatus.NOT_FOUND, "유효하지 않은 리프레쉬 토큰입니다."),
+    INVALID_URI("A009", HttpStatus.BAD_REQUEST, "승인되지 않은 리디렉션 URI입니다.");
 
     private String errorCode;
     private HttpStatus status;

--- a/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
+++ b/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
@@ -26,7 +26,8 @@ public enum ExceptionCode {
     USER_NOT_FOUND("A006", HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     NOT_FOUND_COOKIE("A007", HttpStatus.UNAUTHORIZED, "쿠키를 찾을 수 없습니다."),
     NOT_FOUND_REFRESH_TOKEN("A008", HttpStatus.NOT_FOUND, "유효하지 않은 리프레쉬 토큰입니다."),
-    INVALID_URI("A009", HttpStatus.BAD_REQUEST, "승인되지 않은 리디렉션 URI입니다.");
+    INVALID_URI("A009", HttpStatus.BAD_REQUEST, "승인되지 않은 리디렉션 URI입니다."),
+    ACCESS_DENIED("A010", HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
 
     private String errorCode;
     private HttpStatus status;

--- a/src/main/java/com/inthefridges/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/inthefridges/api/global/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.inthefridges.api.global.security;
 
 import com.inthefridges.api.global.security.handler.CustomAuthenticationFailureHandler;
 import com.inthefridges.api.global.security.handler.CustomAuthenticationSuccessHandler;
+import com.inthefridges.api.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.inthefridges.api.global.security.jwt.filter.ExceptionHandlerFilter;
 import com.inthefridges.api.global.security.jwt.filter.JwtFilter;
 import com.inthefridges.api.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository;
@@ -37,6 +38,7 @@ public class SecurityConfig {
     private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
     private final JwtFilter jwtFilter;
     private final ExceptionHandlerFilter jwtExceptionFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -70,10 +72,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOauthUserService))
                         .successHandler(customAuthenticationSuccessHandler)
                         .failureHandler(customAuthenticationFailureHandler))
-                        .exceptionHandling(exceptionHandling ->
-                                exceptionHandling // TODO : ExceptionCode로 추후 변경하기
-                                .authenticationEntryPoint((httpServletRequest, httpServletResponse, e) -> httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED))
-                                .accessDeniedHandler((httpServletRequest, httpServletResponse, e) -> httpServletResponse.sendError(HttpServletResponse.SC_FORBIDDEN)))
+                .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .addFilterBefore(jwtFilter, OAuth2AuthorizationRequestRedirectFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtFilter.class)
                 .build();

--- a/src/main/java/com/inthefridges/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/inthefridges/api/global/security/SecurityConfig.java
@@ -48,7 +48,16 @@ public class SecurityConfig {
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorise -> authorise
-                        .requestMatchers("/members/**").authenticated()
+                        .requestMatchers("/", "/index.html").permitAll()
+                        .requestMatchers("/favicon.ico").permitAll()
+                        .requestMatchers("/js/**").permitAll()
+                        .requestMatchers("/css/**").permitAll()
+                        .requestMatchers("/img/**", "/image/**", "/images/**").permitAll()
+                        .requestMatchers("/font/**", "/fonts/**").permitAll()
+                        .requestMatchers("/file/**", "/files/**").permitAll()
+                        .requestMatchers("/api/v*/refresh/**").permitAll()
+                        .requestMatchers("/members/**").hasAuthority("MEMBER")
+                        .requestMatchers("/admin/**").hasAuthority("ADMIN")
                         .anyRequest().permitAll())
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorizationEndpointConfig ->

--- a/src/main/java/com/inthefridges/api/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/inthefridges/api/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -1,6 +1,8 @@
 package com.inthefridges.api.global.security.handler;
 
 import com.inthefridges.api.entity.CustomUserDetails;
+import com.inthefridges.api.global.exception.ExceptionCode;
+import com.inthefridges.api.global.exception.ServiceException;
 import com.inthefridges.api.global.security.jwt.JwtService;
 import com.inthefridges.api.global.security.jwt.model.Tokens;
 import com.inthefridges.api.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository;
@@ -11,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -18,6 +21,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 import static com.inthefridges.api.global.security.oauth.repository.HttpCookieOAuthAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
@@ -28,6 +34,8 @@ public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthent
 
     private final JwtService jwtService;
     private final HttpCookieOAuthAuthorizationRequestRepository authorizationRepository;
+    @Value("${oauth2.authorized-redirect-uris}")
+    private final List<String> authorizedRedirectUris;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
@@ -42,11 +50,13 @@ public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthent
     }
 
     private String getRedirectUri(HttpServletRequest request, String accessToken) {
-        String redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue)
-                .orElse(getDefaultTargetUrl());
+        Optional<String> redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
 
-        return UriComponentsBuilder.fromUriString(redirectUri)
+        if(redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get()))
+            throw new ServiceException(ExceptionCode.INVALID_URI);
+
+        return UriComponentsBuilder.fromUriString(redirectUri.orElse(getDefaultTargetUrl()))
                 .queryParam("accessToken", accessToken)
                 .build().toUriString();
     }
@@ -66,5 +76,16 @@ public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthent
     protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
         super.clearAuthenticationAttributes(request);
         authorizationRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private boolean isAuthorizedRedirectUri(String uri){
+        URI clientRedirectUri = URI.create(uri);
+        return authorizedRedirectUris
+                .stream()
+                .anyMatch(authorizedRedirectUris -> {
+                    URI authorizedURI = URI.create(authorizedRedirectUris);
+                    return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                        && authorizedURI.getPort() == clientRedirectUri.getPort();
+                });
     }
 }

--- a/src/main/java/com/inthefridges/api/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/inthefridges/api/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.inthefridges.api.global.security.jwt;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpStatus.*;
+
+import ch.qos.logback.core.spi.ErrorCodes;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inthefridges.api.global.exception.ExceptionCode;
+import com.inthefridges.api.global.exception.ServiceException;
+import com.inthefridges.api.global.exception.response.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
+        log.info(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+        response.setStatus(UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.displayName());
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(
+                        ErrorResponse.of(ExceptionCode.ACCESS_DENIED)));
+    }
+}

--- a/src/main/java/com/inthefridges/api/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/inthefridges/api/global/security/jwt/JwtProvider.java
@@ -57,7 +57,7 @@ public class JwtProvider {
                                     .token(UUID.randomUUID().toString())
                                     .expiryDate(expiredDate)
                                     .build();
-        refreshTokenService.create(refreshToken);
+        refreshTokenService.createOrUpdate(refreshToken);
         return refreshToken.getToken();
     }
 

--- a/src/main/java/com/inthefridges/api/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/inthefridges/api/global/security/jwt/JwtProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -30,11 +31,11 @@ public class JwtProvider {
         this.refreshExpirationMillis = refreshExpirationMillis;
     }
 
-    public String createToken(Long userId, String role, Long TokenValidTime){
+    public String createAccessToken(Long userId, String role){
 
         // 토큰 만료 기간
         Date now = new Date();
-        Date expiredDate = new Date(now.getTime() + TokenValidTime);
+        Date expiredDate = new Date(now.getTime() + accessExpirationMillis);
 
         Map<String, Object> claims = Map.of("userId", userId, "role", role);
 
@@ -46,19 +47,18 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String createAccessToken(Long userId, String role){
-        return createToken(userId, role, accessExpirationMillis);
-    }
-
     public String createRefreshToken(Long memberId, String role){
-        String token = createToken(memberId, role, refreshExpirationMillis);
+        // 토큰 만료 기간
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + refreshExpirationMillis);
         RefreshToken refreshToken = RefreshToken.builder()
-                                    .token(token)
                                     .memberId(memberId)
                                     .role(role)
+                                    .token(UUID.randomUUID().toString())
+                                    .expiryDate(expiredDate)
                                     .build();
         refreshTokenService.create(refreshToken);
-        return token;
+        return refreshToken.getToken();
     }
 
     public Claims getClaims(String token){

--- a/src/main/java/com/inthefridges/api/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/inthefridges/api/global/security/jwt/filter/JwtFilter.java
@@ -2,13 +2,13 @@ package com.inthefridges.api.global.security.jwt.filter;
 
 import com.inthefridges.api.global.security.jwt.JwtService;
 import com.inthefridges.api.global.security.jwt.model.JwtAuthenticationToken;
-import com.inthefridges.api.global.utils.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -29,7 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if(accessToken != null) {
             JwtAuthenticationToken authenticationToken = jwtService.getAuthenticationByAccessToken(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-        }
+       }
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/inthefridges/api/global/security/oauth/service/CustomOAuthUserService.java
+++ b/src/main/java/com/inthefridges/api/global/security/oauth/service/CustomOAuthUserService.java
@@ -48,7 +48,7 @@ public class CustomOAuthUserService extends DefaultOAuth2UserService {
         List<String> roles = memberRoleService.getList(member.getId());
         List<GrantedAuthority> authorities = new ArrayList<>();
         for (String role : roles) {
-            authorities.add(new SimpleGrantedAuthority(role));
+            authorities.add(new SimpleGrantedAuthority(role.toUpperCase()));
         }
 
         return new CustomUserDetails(member, authorities, oAuthUserInfo.getAttributes(), profileImage.getPath());

--- a/src/main/java/com/inthefridges/api/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/RefreshTokenRepository.java
@@ -11,4 +11,5 @@ public interface RefreshTokenRepository {
     Optional<RefreshToken> findByMemberId(Long memberId);
     int create(RefreshToken refreshToken);
     void delete(String RefreshToken);
+    int update(RefreshToken refreshToken);
 }

--- a/src/main/java/com/inthefridges/api/service/DefaultRefreshTokenService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultRefreshTokenService.java
@@ -16,7 +16,7 @@ public class DefaultRefreshTokenService implements RefreshTokenService{
 
     @Override
     public void createOrUpdate(RefreshToken refreshToken) {
-        repository.findById(refreshToken.getToken())
+        repository.findByMemberId(refreshToken.getMemberId())
                 .ifPresentOrElse(
                         existingToken -> repository.update(refreshToken),
                         () -> repository.create(refreshToken)

--- a/src/main/java/com/inthefridges/api/service/DefaultRefreshTokenService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultRefreshTokenService.java
@@ -5,20 +5,22 @@ import com.inthefridges.api.global.exception.ExceptionCode;
 import com.inthefridges.api.global.exception.ServiceException;
 import com.inthefridges.api.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DefaultRefreshTokenService implements RefreshTokenService{
     private final RefreshTokenRepository repository;
 
     @Override
-    public void create(RefreshToken refreshToken) {
-        repository.findByMemberId(refreshToken.getMemberId())
-                .ifPresent(existingToken -> repository.delete(existingToken.getToken()));
-        repository.create(refreshToken);
+    public void createOrUpdate(RefreshToken refreshToken) {
+        repository.findById(refreshToken.getToken())
+                .ifPresentOrElse(
+                        existingToken -> repository.update(refreshToken),
+                        () -> repository.create(refreshToken)
+                );
     }
 
     @Override

--- a/src/main/java/com/inthefridges/api/service/RefreshTokenService.java
+++ b/src/main/java/com/inthefridges/api/service/RefreshTokenService.java
@@ -4,5 +4,5 @@ import com.inthefridges.api.entity.RefreshToken;
 
 public interface RefreshTokenService {
     RefreshToken get(String RefreshToken);
-    void create(RefreshToken refreshToken);
+    void createOrUpdate(RefreshToken refreshToken);
 }

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/src/main/resources/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/mapper/RefreshTokenMapper.xml
@@ -47,6 +47,7 @@
             token = #{token},
             role = #{role}
         </set>
-        WHERE member_id=#{memberId}
+        WHERE member_id=#{memberId} AND
+        deleted_at IS NULL
     </update>
 </mapper>

--- a/src/main/resources/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/mapper/RefreshTokenMapper.xml
@@ -16,18 +16,20 @@
         AND deleted_at IS NULL
     </select>
 
-    <insert id="create" parameterType="RefreshToken">
+    <insert id="create" parameterType="RefreshToken" useGeneratedKeys="true" keyProperty="token">
         INSERT INTO refresh_token
         (
             member_id,
             token,
-            role
+            role,
+            expiry_date
         )
         VALUES
         (
             #{memberId},
             #{token},
-            #{role}
+            #{role},
+            #{expiryDate}
         )
     </insert>
 

--- a/src/main/resources/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/mapper/RefreshTokenMapper.xml
@@ -4,7 +4,7 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.inthefridges.api.repository.RefreshTokenRepository">
 
-    <select id="findById" resultType="RefreshToken">
+    <select id="findById" parameterType="RefreshToken" resultType="RefreshToken">
         SELECT * FROM refresh_token
         WHERE token = #{token}
         AND deleted_at IS NULL
@@ -16,7 +16,7 @@
         AND deleted_at IS NULL
     </select>
 
-    <insert id="create" parameterType="RefreshToken" useGeneratedKeys="true" keyProperty="token">
+    <insert id="create" parameterType="RefreshToken">
         INSERT INTO refresh_token
         (
             member_id,

--- a/src/main/resources/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/mapper/RefreshTokenMapper.xml
@@ -40,4 +40,13 @@
         token = #{token} AND
         deleted_at IS NULL
     </delete>
+
+    <update id="update" parameterType="RefreshToken">
+        UPDATE refresh_token
+        <set>
+            token = #{token},
+            role = #{role}
+        </set>
+        WHERE member_id=#{memberId}
+    </update>
 </mapper>


### PR DESCRIPTION
요약
---
- RefreshToken을 JWT에서 UUID로 변경
- RefreshToken을 통해 AccessToken 발급 시 RefreshToken 함께 재발급
- 로그인 성공 시 Cookie에 담겨있는 RedirectURI와 우리 서비스가 인증하는 RedirectURI가 맞는지 확인
- 인증,인가 에러 발생 시 클라이언트에 응답할 JwtAuthenticationEntryPoint 클래스 구현

변경 내용
---
- RefreshToken을 사용자 정보를 갖고있는 JWT에서 랜덤값 UUID로 변경
- 기존 RefreshToken을 통해 AccessToken 발급 시 AccessToken만 재발급 -> AccessToken과 Refresh 모두 갱신

관련 이슈
---
- #2

기타
---
