### PR TITLE
[feat] http 응답 코드 수정, FileRequest 유효성 검증 추가, 파일 생성 시 fileId 외 OriginName, Path 데이터 추가 반환, fileRepository findByMemberId 추가

### DIFF
--- a/src/main/java/com/inthefridges/api/controller/file/FileController.java
+++ b/src/main/java/com/inthefridges/api/controller/file/FileController.java
@@ -4,6 +4,7 @@ import com.inthefridges.api.dto.request.FileRequest;
 import com.inthefridges.api.dto.response.FileResponse;
 import com.inthefridges.api.global.security.jwt.model.JwtAuthentication;
 import com.inthefridges.api.service.FileService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,7 +22,7 @@ public class FileController {
     private final FileService service;
 
     @GetMapping
-    public ResponseEntity<FileResponse> get(@AuthenticationPrincipal JwtAuthentication member, @RequestBody FileRequest fileRequest){
+    public ResponseEntity<FileResponse> get(@AuthenticationPrincipal JwtAuthentication member, @Valid @RequestBody FileRequest fileRequest){
         FileResponse fileResponse = service.get(member.id(), fileRequest);
         return ResponseEntity.ok(fileResponse);
     }
@@ -33,13 +34,13 @@ public class FileController {
     }
 
     @PutMapping
-    public ResponseEntity<FileResponse> update(@AuthenticationPrincipal JwtAuthentication member, @RequestBody FileRequest fileRequest){
+    public ResponseEntity<FileResponse> update(@AuthenticationPrincipal JwtAuthentication member, @Valid @RequestBody FileRequest fileRequest){
         FileResponse fileResponse = service.update(member.id(), fileRequest);
         return ResponseEntity.ok(fileResponse);
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> delete(@AuthenticationPrincipal JwtAuthentication member, @RequestBody FileRequest fileRequest){
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal JwtAuthentication member, @Valid @RequestBody FileRequest fileRequest){
         service.delete(member.id(), fileRequest);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/inthefridges/api/controller/file/FileController.java
+++ b/src/main/java/com/inthefridges/api/controller/file/FileController.java
@@ -6,6 +6,7 @@ import com.inthefridges.api.global.security.jwt.model.JwtAuthentication;
 import com.inthefridges.api.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +29,7 @@ public class FileController {
     @PostMapping
     public ResponseEntity<FileResponse> create(@AuthenticationPrincipal JwtAuthentication member, @RequestPart(value="file") MultipartFile file){
         FileResponse fileResponse = service.create(member.id(), file);
-        return ResponseEntity.ok(fileResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(fileResponse);
     }
 
     @PutMapping

--- a/src/main/java/com/inthefridges/api/dto/request/FileRequest.java
+++ b/src/main/java/com/inthefridges/api/dto/request/FileRequest.java
@@ -1,8 +1,13 @@
 package com.inthefridges.api.dto.request;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record FileRequest(
+        @PositiveOrZero(message = "아이디는 음수일 수 없습니다.")
         Long id,
+        @PositiveOrZero(message = "냉장고 아이디는 음수일 수 없습니다.")
         Long fridgeId,
+        @PositiveOrZero(message = "식품 아이디는 음수일 수 없습니다.")
         Long itemId
 ) {
 }

--- a/src/main/java/com/inthefridges/api/repository/FileRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/FileRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface FileRepository {
     void save(InFridgeFile file);
     Optional<InFridgeFile> findById(InFridgeFile file);
+    Optional<InFridgeFile> findByMemberId(Long memberId);
     Optional<InFridgeFile> findByIdAndPostId(InFridgeFile file);
     int update(InFridgeFile file);
     void delete(InFridgeFile file);

--- a/src/main/java/com/inthefridges/api/service/DefaultFileService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultFileService.java
@@ -79,7 +79,7 @@ public class DefaultFileService implements FileService{
             throw new ServiceException(ExceptionCode.INTERNAL_SERVER_ERROR);
         }
 
-        return new FileResponse(newFile.getId(), null, null);
+        return new FileResponse(newFile.getId(), dateFolderPath, originalFileName);
     }
 
     @Override
@@ -160,6 +160,26 @@ public class DefaultFileService implements FileService{
     }
 
     /**
+     * memberId 로 member 찾기
+     * @param memberId principal's memberId
+     * @return Member
+     */
+    private Member fetchMemberById(Long memberId) {
+        return memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_MEMBER));
+    }
+
+    /**
+     * principal memberId 와 접근 파일의 작성자 memberId 가 같은지 비교
+     * @param member principal's memberId
+     * @param file 접근하고자하는 파일
+     */
+    private void validateMemberFileMatch(Member member, InFridgeFile file) {
+        if (!file.getMemberId().equals(member.getId()))
+            throw new ServiceException(ExceptionCode.NOT_MATCH_MEMBER);
+    }
+
+    /**
      * FileRequest -> InFridgeFile Entity
      */
     private InFridgeFile convertToFileEntity(Long memberId, FileRequest fileRequest){
@@ -181,25 +201,5 @@ public class DefaultFileService implements FileService{
                 .append(getFileExtension(file.getOriginName()))
                 .toString();
         return new FileResponse(file.getId(), fullPath, file.getOriginName());
-    }
-
-    /**
-     * memberId 로 member 찾기
-     * @param memberId principal's memberId
-     * @return Member
-     */
-    private Member fetchMemberById(Long memberId) {
-        return memberRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_MEMBER));
-    }
-
-    /**
-     * principal memberId 와 접근 파일의 작성자 memberId 가 같은지 비교
-     * @param member principal's memberId
-     * @param file 접근하고자하는 파일
-     */
-    private void validateMemberFileMatch(Member member, InFridgeFile file) {
-        if (!file.getMemberId().equals(member.getId()))
-            throw new ServiceException(ExceptionCode.NOT_MATCH_MEMBER);
     }
 }

--- a/src/main/java/com/inthefridges/api/service/DefaultFileService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultFileService.java
@@ -44,6 +44,24 @@ public class DefaultFileService implements FileService{
     }
 
     @Override
+    public InFridgeFile getProfileImageAndUpdate(InFridgeFile file) {
+        InFridgeFile fetchFile = repository.findByMemberId(file.getMemberId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_FILE));
+
+        // TODO : 리팩토링
+        // OAuth Profile Path
+        if(!fetchFile.getOriginName().equals(fetchFile.getPath()))
+            // 현재 profileImage != 기존 profileImage
+            if (!file.getOriginName().equals(fetchFile.getOriginName())) {
+                repository.delete(fetchFile);
+                repository.save(file);
+                return file;
+            }
+
+        return fetchFile;
+    }
+
+    @Override
     public FileResponse create(Long memberId, MultipartFile requestFile) {
 
         if(requestFile.isEmpty())

--- a/src/main/java/com/inthefridges/api/service/FileService.java
+++ b/src/main/java/com/inthefridges/api/service/FileService.java
@@ -2,11 +2,13 @@ package com.inthefridges.api.service;
 
 import com.inthefridges.api.dto.request.FileRequest;
 import com.inthefridges.api.dto.response.FileResponse;
+import com.inthefridges.api.entity.InFridgeFile;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
 
     FileResponse get(Long memberId, FileRequest fileRequest);
+    InFridgeFile getProfileImageAndUpdate(InFridgeFile file);
     FileResponse create(Long memberId, MultipartFile file);
     FileResponse update(Long memberId, FileRequest fileRequest);
     void delete(Long memberId, FileRequest fileRequest);

--- a/src/main/resources/mapper/FileMapper.xml
+++ b/src/main/resources/mapper/FileMapper.xml
@@ -82,19 +82,12 @@
         UPDATE file
         SET deleted_at = NOW()
         WHERE id = #{id}
-        <choose>
-            <!-- 둘 중 하나만 값이 있는 경우 -->
-            <when test="fridgeId != null and itemId == null">
-                AND fridge_id = #{fridgeId}
-            </when>
-            <when test="itemId != null and fridgeId == null">
-                AND item_id = #{itemId}
-            </when>
-            <!-- 둘 다 값이 있거나, 둘 다 값이 없는 경우 -->
-            <otherwise>
-                AND 1 = 0
-            </otherwise>
-        </choose>
+        <if test="fridgeId != null">
+            AND fridge_id = #{fridgeId},
+        </if>
+        <if test="itemId != null">
+            AND item_id = #{itemId},
+        </if>
         AND deleted_at IS NULL
     </delete>
 

--- a/src/main/resources/mapper/FileMapper.xml
+++ b/src/main/resources/mapper/FileMapper.xml
@@ -10,6 +10,14 @@
         AND deleted_at IS NULL
     </select>
 
+    <select id="findByMemberId">
+        SELECT * FROM file
+        WHERE member_id = #{memberId}
+        AND fridge_id IS NULL
+        AND item_id IS NULL
+        AND deleted_at IS NULL
+    </select>
+
     <select id="findByIdAndPostId" resultType="InFridgeFile">
         SELECT * FROM file
         WHERE id = #{id}


### PR DESCRIPTION
요약
---
- 파일 등록 API 응답 코드 수정
- FileRequest DTO 유효성 검증 추가
- 파일 생성 시 fileId 외 OriginName, Path 데이터 추가 반환
- fileRepository findByMemberId 추가
- profileImagePath를 반환하거나, OAuth profileImagePath 비교 후 Update하는 getProfileImageAndUpdate 메서드 구현

변경 내용
---
* [POST] files API 
  * 기존 응답 코드
  ``` ResponseEntity.ok(fileResponse); ```
  * 수정 응답 코드
  ``` ResponseEntity.status(HttpStatus.CREATED).body(fileResponse); ```

* FileDefaultService create 메서드 데이터 반환 
  * 기존 데이터 반환
 ``` new FileResponse(newFile.getId(), null, null);```
  * 수정된 데이터 반환
 ``` new FileResponse(newFile.getId(), dateFolderPath, originalFileName);```

관련 이슈
---
- 이슈 번호를 작성해 주세요.

기타
---
