### PR TITLE
[feat] 식품 CURD API 구현

### DIFF
--- a/src/main/java/com/inthefridges/api/controller/fridge/item/ItemController.java
+++ b/src/main/java/com/inthefridges/api/controller/fridge/item/ItemController.java
@@ -1,0 +1,75 @@
+package com.inthefridges.api.controller.fridge.item;
+
+import com.inthefridges.api.dto.request.ItemRequest;
+import com.inthefridges.api.dto.response.ItemResponse;
+import com.inthefridges.api.entity.Item;
+import com.inthefridges.api.global.security.jwt.model.JwtAuthentication;
+import com.inthefridges.api.service.ItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/fridges/")
+@RequiredArgsConstructor
+public class ItemController {
+
+    private final ItemService service;
+
+    @GetMapping("{fridgeId}/items")
+    public ResponseEntity<List<ItemResponse>> getList(@AuthenticationPrincipal JwtAuthentication member, @PathVariable Long fridgeId, @RequestParam int storageId){
+        List<ItemResponse> list = service.getList(member.id(), fridgeId, storageId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("{fridgeId}/items/{id}")
+    public ResponseEntity<ItemResponse> get(@AuthenticationPrincipal JwtAuthentication member, @PathVariable Long fridgeId, @PathVariable Long id){
+        ItemResponse itemResponse = service.get(member.id(), fridgeId, id);
+        return ResponseEntity.ok(itemResponse);
+    }
+
+    @PutMapping("{fridgeId}/items/{id}")
+    public ResponseEntity<ItemResponse> update(@AuthenticationPrincipal JwtAuthentication member, @PathVariable Long fridgeId, @PathVariable Long id, @Valid @RequestBody ItemRequest itemRequest){
+        Item item = Item.builder()
+                .id(id)
+                .name(itemRequest.name())
+                .quantity(itemRequest.quantity())
+                .expirationAt(itemRequest.expirationAt())
+                .categoryId(itemRequest.categoryId())
+                .storageId(itemRequest.storageTypeId())
+                .fridgeId(fridgeId)
+                .memberId(member.id())
+                .build();
+        ItemResponse itemResponse = service.update(item);
+        return ResponseEntity.ok(itemResponse);
+    }
+
+    @PostMapping("{fridgeId}/items")
+    public ResponseEntity<ItemResponse> create(@AuthenticationPrincipal JwtAuthentication member, @Valid @RequestBody ItemRequest itemRequest, @PathVariable Long fridgeId){
+        Item item = Item.builder()
+                        .name(itemRequest.name())
+                        .quantity(itemRequest.quantity())
+                        .expirationAt(itemRequest.expirationAt())
+                        .categoryId(itemRequest.categoryId())
+                        .storageId(itemRequest.storageTypeId())
+                        .fridgeId(fridgeId)
+                        .memberId(member.id())
+                        .build();
+        ItemResponse itemResponse = service.create(item);
+        return ResponseEntity.status(HttpStatus.CREATED).body(itemResponse);
+    }
+
+    @DeleteMapping("{fridgeId}/items/{id}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal JwtAuthentication member, @PathVariable Long fridgeId, @PathVariable Long id){
+        service.delete(member.id(), fridgeId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+}
+

--- a/src/main/java/com/inthefridges/api/dto/request/ItemRequest.java
+++ b/src/main/java/com/inthefridges/api/dto/request/ItemRequest.java
@@ -1,0 +1,29 @@
+package com.inthefridges.api.dto.request;
+
+import jakarta.validation.constraints.*;
+
+import java.util.Date;
+
+public record ItemRequest(
+        @NotBlank(message = "식품 이름은 빈칸으로 둘 수 없습니다.")
+        @Size(max = 50, message = "식품 이름은 한 글자 이상, 50자 이내로 작성해야 합니다.")
+        String name,
+
+        @NotNull(message = "수량은 빈칸으로 둘 수 없습니다.")
+        @Positive(message = "수량은 1보다 작을 수 없습니다.")
+        @Max(value = 100000)
+        int quantity,
+
+        @NotNull(message = "유효기간은 빈칸으로 둘 수 없습니다.")
+        @FutureOrPresent(message = "이전 날짜로 유효기간을 등록할 수 없습니다.")
+        Date expirationAt,
+
+        @NotNull(message = "카테고리 아이디는 빈칸으로 둘 수 없습니다.")
+        @PositiveOrZero(message = "카테고리 아이디는 음수일 수 없습니다.")
+        int categoryId,
+
+        @NotNull(message = "저장 타입 아이디는 빈칸으로 둘 수 없습니다.")
+        @PositiveOrZero(message = "저장 타입 아이디는 음수일 수 없습니다.")
+        int storageTypeId
+) {
+}

--- a/src/main/java/com/inthefridges/api/dto/response/ItemResponse.java
+++ b/src/main/java/com/inthefridges/api/dto/response/ItemResponse.java
@@ -1,0 +1,15 @@
+package com.inthefridges.api.dto.response;
+
+import com.inthefridges.api.entity.Category;
+
+import java.util.Date;
+
+public record ItemResponse(
+        Long id,
+        String name,
+        int quantity,
+        Date expirationAt,
+        int storageTypeId,
+        Category category
+) {
+}

--- a/src/main/java/com/inthefridges/api/entity/Category.java
+++ b/src/main/java/com/inthefridges/api/entity/Category.java
@@ -1,0 +1,13 @@
+package com.inthefridges.api.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class Category {
+    int id;
+    String name;
+}

--- a/src/main/java/com/inthefridges/api/entity/Item.java
+++ b/src/main/java/com/inthefridges/api/entity/Item.java
@@ -17,9 +17,10 @@ public class Item {
     private Long memberId;
     private int quantity;
     private Date expirationAt;
+    private Long fridgeId;
+    private int categoryId;
+    private int storageId;
     private Date createdAt;
     private Date updatedAt;
     private Date deletedAt;
-    private Long fridgeId;
-    private Long categoryId;
 }

--- a/src/main/java/com/inthefridges/api/entity/StorageType.java
+++ b/src/main/java/com/inthefridges/api/entity/StorageType.java
@@ -9,9 +9,9 @@ import java.util.Date;
 @Getter
 @AllArgsConstructor
 public class StorageType {
-    private Long id;
+    private int id;
     private String name;
-    private Date createdAt;
-    private Date updatedAt;
-    private Date deletedAt;
+//    private Date createdAt;
+//    private Date updatedAt;
+//    private Date deletedAt;
 }

--- a/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
+++ b/src/main/java/com/inthefridges/api/global/exception/ExceptionCode.java
@@ -35,7 +35,17 @@ public enum ExceptionCode {
     NOT_FOUND_FRIDGE("FR001", HttpStatus.NOT_FOUND, "냉장고를 찾을 수 없습니다."),
 
     // File
-    NOT_FOUND_FILE("FI001", HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다.");
+    NOT_FOUND_FILE("FI001", HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+
+    // Category
+    NOT_FOUND_CATEGORY("CT001", HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+
+    // StorageType
+    NOT_FOUND_STORAGE_TYPE("S001", HttpStatus.NOT_FOUND, "저장 타입을 찾을 수 없습니다."),
+
+    // Item
+    NOT_FOUND_ITEM("I001", HttpStatus.NOT_FOUND, "식품을 찾을 수 없습니다."),;
+
 
     private String errorCode;
     private HttpStatus status;

--- a/src/main/java/com/inthefridges/api/repository/CategoryRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.inthefridges.api.repository;
+
+import com.inthefridges.api.entity.Category;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface CategoryRepository {
+    Optional<Category> findById(int id);
+}

--- a/src/main/java/com/inthefridges/api/repository/ItemRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/ItemRepository.java
@@ -1,0 +1,17 @@
+package com.inthefridges.api.repository;
+
+import com.inthefridges.api.entity.Item;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface ItemRepository {
+    int save(Item item);
+    Optional<Item> findById(Long id);
+    Optional<Item> findByIdAndFridgeId(Long id, Long fridgeId);
+    List<Item> findAllByFridgeIdAndStorageId(Long fridgeId, int storageId);
+    int update(Item item);
+    void delete(Long id, Long fridgeId);
+}

--- a/src/main/java/com/inthefridges/api/repository/StorageTypeRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/StorageTypeRepository.java
@@ -1,0 +1,11 @@
+package com.inthefridges.api.repository;
+
+import com.inthefridges.api.entity.StorageType;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface StorageTypeRepository {
+    Optional<StorageType> findById(int id);
+}

--- a/src/main/java/com/inthefridges/api/service/DefaultFridgeService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultFridgeService.java
@@ -22,8 +22,8 @@ import java.util.List;
 public class DefaultFridgeService implements FridgeService {
 
     private final FridgeRepository repository;
-    private final MemberRepository memberRepository;
     private final FileRepository fileRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public List<FridgeResponse> getList(Long memberId) {
@@ -87,19 +87,11 @@ public class DefaultFridgeService implements FridgeService {
     }
 
     /**
-     * Fridge Entity -> FridgeResponse
-     */
-    private FridgeResponse convertToFridgeResponse(Fridge fridge){
-        return new FridgeResponse(fridge.getId(), fridge.getName(), null);
-    }
-
-
-    /**
      * fridgeId 로 fridge 찾기
      * @param id fridgeId
      * @return Fridge
      */
-    private Fridge fetchFridgeById(Long id) {
+    public Fridge fetchFridgeById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_FRIDGE));
     }
@@ -109,18 +101,28 @@ public class DefaultFridgeService implements FridgeService {
      * @param memberId principal's memberId
      * @return Member
      */
-    private Member fetchMemberById(Long memberId) {
+    public Member fetchMemberById(Long memberId) {
         return memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_MEMBER));
     }
 
     /**
-     * principal memberId 와 수정하려는 냉장고의 작성자 memberId 가 같은지 비교
+     * principal memberId 와 접근하려는 냉장고의 등록자 memberId 가 같은지 비교
      * @param member principal's memberId
-     * @param fridge 수정하려는 냉장고
+     * @param fridge 접근하려는 냉장고
      */
-    private void validateMemberFridgeMatch(Member member, Fridge fridge) {
+    public void validateMemberFridgeMatch(Member member, Fridge fridge) {
         if (!fridge.getMemberId().equals(member.getId()))
             throw new ServiceException(ExceptionCode.NOT_MATCH_MEMBER);
     }
+
+    /**
+     * Fridge Entity -> FridgeResponse
+     */
+    private FridgeResponse convertToFridgeResponse(Fridge fridge){
+        return new FridgeResponse(fridge.getId(), fridge.getName(), null);
+    }
+
+
+
 }

--- a/src/main/java/com/inthefridges/api/service/DefaultItemService.java
+++ b/src/main/java/com/inthefridges/api/service/DefaultItemService.java
@@ -1,0 +1,145 @@
+package com.inthefridges.api.service;
+
+import com.inthefridges.api.dto.response.ItemResponse;
+import com.inthefridges.api.entity.Category;
+import com.inthefridges.api.entity.Fridge;
+import com.inthefridges.api.entity.Item;
+import com.inthefridges.api.entity.Member;
+import com.inthefridges.api.global.exception.ExceptionCode;
+import com.inthefridges.api.global.exception.ServiceException;
+import com.inthefridges.api.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultItemService implements ItemService{
+    private final ItemRepository repository;
+    private final MemberRepository memberRepository;
+    private final FridgeRepository fridgeRepository;
+    private final CategoryRepository categoryRepository;
+    private final StorageTypeRepository storageTypeRepository;
+
+    @Override
+    public ItemResponse create(Item item) {
+        memberRepository.findByMemberId(item.getMemberId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_MEMBER));
+
+        fridgeRepository.findById(item.getFridgeId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_FRIDGE));
+
+        Category category = categoryRepository.findById(item.getCategoryId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_CATEGORY));
+
+        storageTypeRepository.findById(item.getStorageId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_STORAGE_TYPE));
+
+        repository.save(item);
+
+        Item findItem = repository.findById(item.getId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_ITEM));
+
+        return convertToItemResponse(findItem, category);
+    }
+
+    @Override
+    public ItemResponse get(Long memberId, Long fridgeId, Long id) {
+        Member member = fetchMemberById(memberId);
+        Item item = fetchItemById(id);
+        validateMemberFridgeMatch(member, item);
+
+        Item findItem = repository.findByIdAndFridgeId(id, fridgeId)
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_ITEM));
+        Category category = categoryRepository.findById(item.getCategoryId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_CATEGORY));
+
+        return convertToItemResponse(findItem, category);
+    }
+
+    @Override
+    public List<ItemResponse> getList(Long memberId, Long fridgeId, int storageId) {
+
+        List<Item> items = repository.findAllByFridgeIdAndStorageId(fridgeId, storageId);
+
+        return items.stream()
+                .map(findItem -> {
+                    Category category = categoryRepository.findById(findItem.getCategoryId())
+                            .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_CATEGORY));
+                    return convertToItemResponse(findItem, category);
+                })
+                .toList();
+    }
+
+    @Override
+    public ItemResponse update(Item item) {
+        Member member = fetchMemberById(item.getMemberId());
+        Item fetchItem = fetchItemById(item.getId());
+        validateMemberFridgeMatch(member, fetchItem);
+
+        fetchItem.setName(item.getName());
+        fetchItem.setCategoryId(item.getCategoryId());
+        fetchItem.setQuantity(item.getQuantity());
+        fetchItem.setExpirationAt(item.getExpirationAt());
+
+        repository.update(fetchItem);
+        Item findItem = repository.findById(fetchItem.getId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_ITEM));
+        Category category = categoryRepository.findById(findItem.getCategoryId())
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_CATEGORY));
+
+        return convertToItemResponse(fetchItem, category);
+    }
+
+    @Override
+    public void delete(Long memberId, Long fridgeId, Long id) {
+        Member member = fetchMemberById(memberId);
+        Item fetchItem = fetchItemById(id);
+        validateMemberFridgeMatch(member, fetchItem);
+
+        repository.delete(id, fridgeId);
+    }
+
+    /**
+     * itemId 로 item 찾기
+     * @param id itemId
+     * @return Item
+     */
+    public Item fetchItemById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_ITEM));
+    }
+
+    /**
+     * memberId 로 member 찾기
+     * @param memberId principal's memberId
+     * @return Member
+     */
+    public Member fetchMemberById(Long memberId) {
+        return memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ServiceException(ExceptionCode.NOT_FOUND_MEMBER));
+    }
+
+    /**
+     * principal memberId 와 식품 등록록 memberId 가 같은지 비교
+     * @param member principal's memberId
+     * @param item 식품
+     */
+    public void validateMemberFridgeMatch(Member member, Item item) {
+        if (!item.getMemberId().equals(member.getId()))
+            throw new ServiceException(ExceptionCode.NOT_MATCH_MEMBER);
+    }
+
+    /**
+     * Item Entity -> ItemResponse
+     */
+    private ItemResponse convertToItemResponse(Item item, Category category){
+        return new ItemResponse(item.getId(),
+                                item.getName(),
+                                item.getQuantity(),
+                                item.getExpirationAt(),
+                                item.getStorageId(),
+                                category);
+    }
+}

--- a/src/main/java/com/inthefridges/api/service/ItemService.java
+++ b/src/main/java/com/inthefridges/api/service/ItemService.java
@@ -1,0 +1,14 @@
+package com.inthefridges.api.service;
+
+import com.inthefridges.api.dto.response.ItemResponse;
+import com.inthefridges.api.entity.Item;
+
+import java.util.List;
+
+public interface ItemService {
+    ItemResponse create(Item item);
+    ItemResponse get(Long memberId, Long fridgeId, Long id);
+    List<ItemResponse> getList(Long memberId, Long fridgeId, int storageId);
+    ItemResponse update(Item item);
+    void delete(Long memberId, Long fridgeId, Long id);
+}

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.inthefridges.api.repository.CategoryRepository">
+
+    <select id="findById" resultType="Category">
+        SELECT * FROM category
+        WHERE id = #{id}
+        AND deleted_at IS NULL
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/ItemMapper.xml
+++ b/src/main/resources/mapper/ItemMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.inthefridges.api.repository.ItemRepository">
+
+    <select id="findById" resultType="Item">
+        SELECT * FROM item
+        WHERE id = #{id}
+        AND deleted_at IS NULL
+    </select>
+
+    <select id="findByIdAndFridgeId" resultType="Item">
+        SELECT * FROM item
+        WHERE id = #{id}
+        AND fridge_id = #{fridgeId}
+        AND deleted_at IS NULL
+    </select>
+
+    <select id="findAllByFridgeIdAndStorageId" resultType="Item">
+        SELECT * FROM item
+        WHERE fridge_id = #{fridgeId}
+        AND storage_id = #{storageId}
+        AND deleted_at IS NULL
+    </select>
+
+
+    <insert id="save" parameterType="Item" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO item
+        (
+            name,
+            member_id,
+            quantity,
+            expiration_at,
+            fridge_id,
+            category_id,
+            storage_id
+        )
+        VALUES
+        (
+            #{name},
+            #{memberId},
+            #{quantity},
+            #{expirationAt},
+            #{fridgeId},
+            #{categoryId},
+            #{storageId}
+        )
+    </insert>
+
+    <delete id="delete">
+        UPDATE item
+        SET deleted_at = NOW()
+        WHERE id = #{id}
+        AND fridge_id = #{fridgeId}
+        AND deleted_at IS NULL
+    </delete>
+
+    <update id="update" parameterType="Item">
+        UPDATE item
+        <set>
+            name = #{name},
+            quantity = #{quantity},
+            expiration_at = #{expirationAt},
+            fridge_id = #{fridgeId},
+            storage_id = #{storageId}
+        </set>
+        WHERE id = #{id}
+        AND deleted_at IS NULL
+    </update>
+</mapper>

--- a/src/main/resources/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/mapper/RefreshTokenMapper.xml
@@ -16,7 +16,7 @@
         AND deleted_at IS NULL
     </select>
 
-    <insert id="create" parameterType="RefreshToken">
+    <insert id="save" parameterType="RefreshToken">
         INSERT INTO refresh_token
         (
             member_id,

--- a/src/main/resources/mapper/StorageTypeMapper.xml
+++ b/src/main/resources/mapper/StorageTypeMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.inthefridges.api.repository.StorageTypeRepository">
+
+    <select id="findById" resultType="StorageType">
+        SELECT * FROM storage_type
+        WHERE id = #{id}
+        AND deleted_at IS NULL
+    </select>
+
+</mapper>

--- a/src/test/java/com/inthefridges/api/service/DefaultFridgeServiceTest.java
+++ b/src/test/java/com/inthefridges/api/service/DefaultFridgeServiceTest.java
@@ -59,11 +59,17 @@ class DefaultFridgeServiceTest {
     @DisplayName("냉장고 아이디로 냉장고 조회 성공")
     void get() {
         // given
-        Fridge fridge = Fridge.builder().name("냉장고").memberId(10L).build();
+        Fridge fridge = Fridge.builder()
+                .name("냉장고")
+                .memberId(10L)
+                .build();
+        Member member = Member.builder()
+                .id(1L)
+                .build();
         given(repository.findById(anyLong())).willReturn(Optional.ofNullable(fridge));
 
         // when
-        FridgeResponse fridgeResponse = service.get(10L);
+        FridgeResponse fridgeResponse = service.get(member.getId(), 10L);
 
         // then
         assertThat(fridgeResponse.name()).isEqualTo(fridge.getName());
@@ -74,14 +80,14 @@ class DefaultFridgeServiceTest {
     @DisplayName("냉장고 등록 성공")
     void create() {
         // given
-        FridgeRequest fridgeRequest = new FridgeRequest("토리냉장고");
+        FridgeRequest fridgeRequest = new FridgeRequest("토리냉장고", null);
         Fridge fridge = createFridgeEntity(fridgeRequest);
         Member member = Member.builder()
                         .id(1L)
                         .build();
 
         given(memberRepository.findByMemberId(anyLong())).willReturn(Optional.ofNullable(member));
-        given(repository.create(any())).willReturn(1);
+        given(repository.save(any())).willReturn(1);
         given(repository.findById(anyLong()+1)).willReturn(Optional.ofNullable(fridge));
 
         // when

--- a/src/test/java/com/inthefridges/api/service/DefaultItemServiceTest.java
+++ b/src/test/java/com/inthefridges/api/service/DefaultItemServiceTest.java
@@ -1,0 +1,107 @@
+package com.inthefridges.api.service;
+
+import com.inthefridges.api.dto.response.ItemResponse;
+import com.inthefridges.api.entity.*;
+import com.inthefridges.api.repository.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultItemServiceTest {
+
+    @InjectMocks
+    private DefaultItemService service;
+    @Mock
+    private ItemRepository repository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private FridgeRepository fridgeRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private StorageTypeRepository storageTypeRepository;
+
+    @BeforeEach
+    void setup(){
+        // Member
+        Member member = Member.builder()
+                        .id(10L)
+                        .build();
+        given(memberRepository.findByMemberId(anyLong())).willReturn(Optional.ofNullable(member));
+
+        // Fridge
+        Fridge fridge = Fridge.builder()
+                .id(7L)
+                .name("김치냉장고")
+                .memberId(10L)
+                .build();
+        given(fridgeRepository.findById(anyLong())).willReturn(Optional.ofNullable(fridge));
+
+        // Category
+        Category category = new Category(1, "해산물");
+        given(categoryRepository.findById(anyInt())).willReturn(Optional.ofNullable(category));
+
+        // storageType
+        StorageType storageType = new StorageType(1, "냉장");
+        given(storageTypeRepository.findById(anyInt())).willReturn(Optional.ofNullable(storageType));
+
+        // item
+        Item item = Item
+                .builder()
+                .id(7L)
+                .name("계란")
+                .memberId(10L)
+                .fridgeId(7L)
+                .categoryId(1)
+                .storageTypeId(1)
+                .quantity(30)
+                .build();
+        given(repository.save(any())).willReturn(Math.toIntExact(item.getId()));
+        given(repository.findById(anyLong())).willReturn(Optional.ofNullable(item));
+//        given(repository.findByIdAndFridgeId(anyLong(), anyLong())).willReturn(Optional.ofNullable(item));
+
+
+        List<Item> items = Arrays.asList(
+                Item.builder().id(1L).name("요거트").memberId(10L).fridgeId(7L).categoryId(1).storageTypeId(1).build(),
+                Item.builder().id(3L).name("생수").memberId(10L).fridgeId(7L).categoryId(1).storageTypeId(1).build(),
+                Item.builder().id(4L).name("불고기").memberId(10L).fridgeId(7L).categoryId(1).storageTypeId(1).build()
+        );
+        given(repository.findAllByFridgeIdAndStorageId(anyLong(), anyInt())).willReturn(items);
+    }
+
+    @Test
+    @DisplayName("식품 등록 성공")
+    void create() throws Exception {
+        //given
+        Item item = Item.builder()
+                .id(7L)
+                .fridgeId(7L)
+                .name("계란")
+                .memberId(10L)
+                .categoryId(1)
+                .storageTypeId(1)
+                .quantity(30)
+                .build();
+        
+        //when
+        ItemResponse itemResponse = service.create(item);
+
+        //then
+        Assertions.assertThat(itemResponse.storageTypeId()).isEqualTo(item.getStorageTypeId());
+
+    }
+}


### PR DESCRIPTION
요약
---
- 식품 Entity, Controller, Service, Repository 구현
- 식품 카테고리, 식품 저장 타입의 Entity, Repository 등 구현

변경 내용
---
- 변경 내용을 작성해 주세요.

관련 이슈
---
- 이슈 번호를 작성해 주세요.

기타
---
