### PR TITLE
[feat] 회원 탈퇴시 social_id + uuid 적용되어 재가입 가능하도록 구현

### DIFF
--- a/src/main/java/com/inthefridges/api/repository/MemberRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/MemberRepository.java
@@ -12,5 +12,5 @@ public interface MemberRepository {
     Optional<Member> findByUsername(String username);
     int save(Member Member);
     int update(Member member);
-    int delete(Long id);
+    int delete(Long id, String updatedSocialId);
 }

--- a/src/main/java/com/inthefridges/api/repository/MemberRoleRepository.java
+++ b/src/main/java/com/inthefridges/api/repository/MemberRoleRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface MemberRoleRepository {
     int save(MemberRole memberRole);
     List<String> findByMemberId(Long memberId);
+
+    int delete(Long memberId);
 }

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -50,7 +50,10 @@
 
     <delete id="delete">
         UPDATE member
-        SET deleted_at = NOW()
+        <set>
+            social_id = #{updatedSocialId},
+            deleted_at = NOW()
+        </set>
         WHERE
         id = #{id} AND
         deleted_at IS NULL

--- a/src/main/resources/mapper/MemberRoleMapper.xml
+++ b/src/main/resources/mapper/MemberRoleMapper.xml
@@ -11,7 +11,7 @@
         AND deleted_at IS NULL
     </select>
 
-    <insert id="create" parameterType="MemberRole" useGeneratedKeys="true" keyProperty="id">
+    <insert id="save" parameterType="MemberRole" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO member_role
         (
             member_id,
@@ -23,4 +23,14 @@
             #{roleId}
         )
     </insert>
+
+    <delete id="delete">
+        UPDATE member_role
+        <set>
+            deleted_at = NOW()
+        </set>
+        WHERE
+        member_id = #{memberId} AND
+        deleted_at IS NULL
+    </delete>
 </mapper>


### PR DESCRIPTION
요약
---
- 탈퇴시 Role, Profile 삭제 구현
- 탈퇴시 유니크키 social_id에 고유 uuid를 추가해 추후 재가입을 가능하도록 구현

변경 내용
---
- 변경 내용을 작성해 주세요.

관련 이슈
---
- 이슈 번호를 작성해 주세요.

기타
---
